### PR TITLE
Made pie chart only show dots on hover

### DIFF
--- a/frontend/components/ReportCharts/TransitionOfParliament/TransitionOfParliament.tsx
+++ b/frontend/components/ReportCharts/TransitionOfParliament/TransitionOfParliament.tsx
@@ -7,7 +7,7 @@ const TransitionOfParliament: React.FC = () => {
     const [dataArray, setDataArray] = useState<DataItem[]>([]);
 
     useEffect(() => {
-        const fetchIssues = async () => {   
+        const fetchIssues = async () => {
             try {
                 const url = `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/reports/groupedResolutionAndCategory`;
                 const response = await fetch(url, {
@@ -35,11 +35,11 @@ const TransitionOfParliament: React.FC = () => {
 
         fetchIssues();
     }, []);
-    
+
     useEffect(() => {
         const transformData = (data: { resolved: { [key: string]: number }, unresolved: { [key: string]: number } }) => {
             const merged = { ...data.resolved };
-            
+
             Object.entries(data.unresolved).forEach(([key, value]) => {
                 if (merged[key]) {
                     merged[key] += value;
@@ -47,7 +47,7 @@ const TransitionOfParliament: React.FC = () => {
                     merged[key] = value;
                 }
             });
-            
+
             return Object.entries(merged).map(([name, value]) => ({ name, value }));
         };
 
@@ -190,7 +190,11 @@ const TransitionOfParliament: React.FC = () => {
             const chartElement = document.getElementById("transitionOfParliament");
 
             if (chartElement) {
-                const myChart = echarts.init(chartElement);
+                const myChart = echarts.init(
+                  chartElement,
+                  null,
+                  { width: 500 }
+                );
                 myChart.setOption(currentOption);
 
                 chartElement.onmouseenter = () => {
@@ -213,7 +217,7 @@ const TransitionOfParliament: React.FC = () => {
         <div className="col-lg-6">
             <div className="card">
                 <div className="card-body">
-                    <div id="transitionOfParliament" style={{ width: '100%', height: '400px' }} className="echart"></div>
+                    <div id="transitionOfParliament" style={{ width: 'max-content', height: '400px' }} className="echart mx-auto"></div>
                 </div>
             </div>
         </div>

--- a/frontend/components/ReportCharts/TransitionOfParliament/TransitionOfParliament.tsx
+++ b/frontend/components/ReportCharts/TransitionOfParliament/TransitionOfParliament.tsx
@@ -193,13 +193,16 @@ const TransitionOfParliament: React.FC = () => {
                 const myChart = echarts.init(chartElement);
                 myChart.setOption(currentOption);
 
-                const intervalId = setInterval(() => {
-                    currentOption = currentOption === pieOption ? parliamentOption : pieOption;
-                    myChart.setOption(currentOption);
-                }, 2000);
+                chartElement.onmouseenter = () => {
+                    myChart.setOption(parliamentOption);
+                };
+
+                chartElement.onmouseleave = () => {
+                    myChart.setOption(pieOption);
+                };
+
 
                 return () => {
-                    clearInterval(intervalId);
                     myChart.dispose();
                 };
             }

--- a/frontend/components/ReportCharts/TransitionOfParliament/TransitionOfParliament.tsx
+++ b/frontend/components/ReportCharts/TransitionOfParliament/TransitionOfParliament.tsx
@@ -186,7 +186,6 @@ const TransitionOfParliament: React.FC = () => {
                 } as echarts.EChartsOption;
             })();
 
-            let currentOption: echarts.EChartsOption = pieOption;
             const chartElement = document.getElementById("transitionOfParliament");
 
             if (chartElement) {
@@ -195,7 +194,7 @@ const TransitionOfParliament: React.FC = () => {
                   null,
                   { width: 500 }
                 );
-                myChart.setOption(currentOption);
+                myChart.setOption(pieOption);
 
                 chartElement.onmouseenter = () => {
                     myChart.setOption(parliamentOption);


### PR DESCRIPTION
One of the points in the feedback was that it was distracting for the pie chart to periodically switch to dots. It was suggested that it should only show dots when hovering. This implements that.