### PR TITLE
Enhance Dot Visualization with Issue Rate-Based Scaling

### DIFF
--- a/frontend/components/Visualisations/DotVisualizations.tsx
+++ b/frontend/components/Visualisations/DotVisualizations.tsx
@@ -28,6 +28,18 @@ const EChartsComponent = () => {
     enabled: true,
   });
 
+  const provincesPopulation: { [key: string]: number } = {
+    "Eastern Cape": 6676590,
+    "Free State": 2745590,
+    "Gauteng": 15810388,
+    "KwaZulu-Natal": 11513575,
+    "Limpopo": 5926724,
+    "Mpumalanga": 4743584,
+    "North West": 4108816,
+    "Northern Cape": 1303047,
+    "Western Cape": 7113776
+  };
+
   useEffect(() => {
     if (isLoading || isError) {
       return;
@@ -38,62 +50,105 @@ const EChartsComponent = () => {
 
     function run() {
       const dataWrap = prepareData(data);
-      initChart(dataWrap.seriesData, dataWrap.maxDepth);
+      initChart(dataWrap.seriesData, dataWrap.maxDepth, dataWrap.maxIssueRate);
     }
 
     function prepareData(rawData: SubData) {
       const seriesData: SeriesDataItem[] = [];
       let maxDepth = 0;
+      let maxIssueRate = 0;
 
+      seriesData.push({
+        id: "South Africa",
+        value: rawData.$count || 0,
+        population: 0,
+        issueRate: 0,
+        depth: 0,
+        index: 0,
+      });
+    
       function convert(source: SubData, basePath: string, depth: number) {
-        if (source == null) {
-          return;
-        }
-        if (maxDepth > 5) {
+        if (source == null || maxDepth > 5) {
           return;
         }
         maxDepth = Math.max(depth, maxDepth);
-        seriesData.push({
-          id: basePath,
-          value: source.$count!,
-          depth: depth,
-          index: seriesData.length,
-        });
-
+        
+        let count = source.$count || 0;
+        let population = 0;
+        let issueRate = 0;
+        
+        if (depth === 1) {
+          const provinceName = basePath.split(", ")[1];
+          if (provincesPopulation[provinceName]) {
+            population = provincesPopulation[provinceName];
+            issueRate = Math.log(count + 1) / Math.log(population) * 10000;
+            
+            maxIssueRate = Math.max(maxIssueRate, issueRate);
+            seriesData.push({
+              id: basePath,
+              value: count,
+              population: population,
+              issueRate: issueRate,
+              depth: depth,
+              index: seriesData.length,
+            });
+          }
+        } else if (depth > 1) {
+          seriesData.push({
+            id: basePath,
+            value: count,
+            population: population,
+            issueRate: issueRate,
+            depth: depth,
+            index: seriesData.length,
+          });
+        }
+      
         for (const key in source) {
-          if (
-            Object.prototype.hasOwnProperty.call(source, key) &&
-            !key.match(/^\$/)
-          ) {
+          if (Object.prototype.hasOwnProperty.call(source, key) && !key.match(/^\$/)) {
             const path = basePath + ", " + key;
             convert(source[key] as SubData<unknown>, path, depth + 1);
           }
         }
       }
+      
       convert(rawData, "South Africa", 0);
+      
       return {
         seriesData: seriesData,
         maxDepth: maxDepth,
+        maxIssueRate: maxIssueRate
       };
     }
 
-    function initChart(seriesData: SeriesDataItem[], maxDepth: number) {
+    function initChart(seriesData: SeriesDataItem[], maxDepth: number, maxIssueRate: number) {
       let displayRoot = stratify() as d3.HierarchyCircularNode<SeriesDataItem>;
 
       function stratify() {
         return d3
           .stratify<SeriesDataItem>()
           .parentId((d: SeriesDataItem): string => {
+            if (d.id === "South Africa") return "";
             return d.id.substring(0, d.id.lastIndexOf(", "));
           })(seriesData)
           .sum((d: SeriesDataItem): number => {
-            return d.value || 0;
+            if (d.depth === 0) return 0;
+            if (d.depth === 1) {
+              const minSize = 1000;
+              const maxSize = 100000;
+              const size = Math.sqrt(minSize + (d.issueRate / maxIssueRate) * (maxSize - minSize)) * 50;
+              // console.log(`Province: ${d.id}, Count: ${d.value}, Population: ${d.population}, Issue Rate: ${d.issueRate.toFixed(8)}, Calculated Size: ${size.toFixed(2)}`);
+              return size;
+            }
+            return 1;
           })
           .sort(
             (
               a: d3.HierarchyNode<SeriesDataItem>,
               b: d3.HierarchyNode<SeriesDataItem>,
             ): number => {
+              if (a.depth === 0) return -1;
+              if (b.depth === 0) return 1;
               return (b.value || 0) - (a.value || 0);
             },
           );

--- a/frontend/components/Visualisations/DotVisualizations.tsx
+++ b/frontend/components/Visualisations/DotVisualizations.tsx
@@ -73,7 +73,7 @@ const EChartsComponent = () => {
         }
         maxDepth = Math.max(depth, maxDepth);
         
-        let count = source.$count || 0;
+        const count = source.$count || 0;
         let population = 0;
         let issueRate = 0;
         

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -128,6 +128,8 @@ type SubData<T = unknown> = {
 interface SeriesDataItem {
   id: string;
   value: number;
+  population: number;
+  issueRate: number;
   depth: number;
   index: number;
 }


### PR DESCRIPTION
## Changes
- Added population data for all provinces
- Implemented logarithmic issue rate calculation to better handle small differences
- Modified the `stratify` function to scale province sizes based on calculated issue rates
- Adjusted rendering to emphasize province-level visualization
- Removed issues that do not have locations associated with them

## Why
The previous visualization didn't account for the population differences between provinces, potentially misrepresenting the relative significance of issues. This new approach provides a more nuanced view, allowing users to quickly identify provinces with disproportionately high issue rates relative to their population. As you can see in the screenshot below. Gauteng has more than double the issues of both WC and Limpopo, but the size of the dot is not double the size.



![image](https://github.com/user-attachments/assets/68acbafe-f845-4782-8b81-507593f0676f)

## Notes
- The scaling factors and logarithmic calculation can be further tuned if needed
- We may want to consider adding a legend or tooltip to explain the new scaling method to users
- A sacrifice I had to make was making the categories inside the province the same size

## Further improvement
- A color intensity scale that is linked to the issue rate in each province
- Removing the placing the province data into another file
- The formulas can be tweaked to show the size differences better

