### PR TITLE
Add Political Association Dropdown to Resolution Modal

### DIFF
--- a/frontend/components/ResolutionModal/ResolutionModal.tsx
+++ b/frontend/components/ResolutionModal/ResolutionModal.tsx
@@ -15,6 +15,8 @@ import { useTheme } from "next-themes";
 import { cn } from "@/lib/utils";
 import { Upload, X } from "lucide-react";
 import Image from 'next/image';
+import Dropdown from "@/components/Dropdown/Dropdown"; 
+import { politicalAssociationOptions  } from "@/lib/constants"; 
 
 interface ResolutionModalProps {
   isOpen: boolean;
@@ -43,7 +45,7 @@ const ResolutionModal: React.FC<ResolutionModalProps> = ({
     isSelfResolution ? 'self' : 'unknown'
   );
   const [resolvedBy, setResolvedBy] = useState('');
-  const [politicalAssociation, setPoliticalAssociation] = useState('');
+  const [politicalAssociation, setPoliticalAssociation] = useState('NONE');
   const [stateEntityAssociation, setStateEntityAssociation] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { theme } = useTheme();
@@ -55,7 +57,7 @@ const ResolutionModal: React.FC<ResolutionModalProps> = ({
       proofImage,
       resolutionSource,
       resolvedBy: resolutionSource === 'other' ? resolvedBy : undefined,
-      politicalAssociation: !isSelfResolution ? politicalAssociation : undefined,
+      politicalAssociation: resolutionSource !== 'unknown' ? politicalAssociation : undefined,
       stateEntityAssociation: !isSelfResolution ? stateEntityAssociation : undefined,
     });
     resetForm();
@@ -67,7 +69,7 @@ const ResolutionModal: React.FC<ResolutionModalProps> = ({
     setImagePreview(null);
     setResolutionSource(isSelfResolution ? 'self' : 'unknown');
     setResolvedBy('');
-    setPoliticalAssociation('');
+    setPoliticalAssociation('NONE');
     setStateEntityAssociation('');
   };
 
@@ -143,16 +145,19 @@ const ResolutionModal: React.FC<ResolutionModalProps> = ({
             />
           </div>
 
-          {!isSelfResolution && (
+          {!isSelfResolution && resolutionSource !== 'unknown' && (
             <>
               <div>
                 <Label htmlFor="politicalAssociation">Political Association (optional)</Label>
-                <Input
-                  id="politicalAssociation"
-                  value={politicalAssociation}
-                  onChange={(e) => setPoliticalAssociation(e.target.value)}
-                  placeholder="Political association (if any)"
-                />
+                <div className="w-full">
+                  <Dropdown
+                    options={politicalAssociationOptions}
+                    value={politicalAssociation}
+                    onChange={setPoliticalAssociation}
+                    placeholder="Select political association"
+                    className="w-full"
+                  />
+                </div>
               </div>
 
               <div>

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -21,3 +21,30 @@ export const moodOptions = {
     { value: "Happy", label: "Happy", emoji: "😊" },
   ],
 };
+
+export const politicalAssociationOptions = {
+  group: "Political Associations",
+  items: [
+    { value: "ANC", label: "African National Congress (ANC)" },
+    { value: "DA", label: "Democratic Alliance (DA)" },
+    { value: "MK", label: "uMkhonto weSizwe (MK)"},
+    { value: "EFF", label: "Economic Freedom Fighters (EFF)" },
+    { value: "IFP", label: "Inkatha Freedom Party (IFP)" },
+    { value: "PA", label: "Patriotic Alliance (PA)"},
+    { value: "FF+", label: "Freedom Front Plus (FF+)" },
+    { value: "ActionSA", label: "ActionSA" },
+    { value: "RISE Mzansi", label: "RISE Mzansi" },
+    { value: "ACDP", label: "African Christian Democratic Party (ACDP)" },
+    { value: "BOSA", label: "Build One South Africa (BOSA)" },
+    { value: "UDM", label: "United Democratic Movement (UDM)" },
+    { value: "COPE", label: "Congress of the People (COPE)" },
+    { value: "NFP", label: "National Freedom Party (NFP)" },
+    { value: "ATM", label: "African Transformation Movement (ATM)" },
+    { value: "GOOD", label: "GOOD Party" },
+    { value: "AL JAMA-AH", label: "Al Jama-ah" },
+    { value: "PAC", label: "Pan Africanist Congress of Azania (PAC)" },
+    { value: "UAT", label: "United Africans Transformation (UAT) "},
+    { value: "NONE", label: "None" },
+    { value: "OTHER", label: "Other" },
+  ],
+};


### PR DESCRIPTION
## Description
This PR updates the ResolutionModal component to replace the free-text input for political association with a dropdown menu. This change improves data consistency and user experience by providing a predefined list of political associations to choose from.

## Changes
- Replace the Input component for political association with a Dropdown component
- Add politicalAssociationOptions to constants file
- Set "None" as the default selection for political association
- Ensure the dropdown is only shown when appropriate (not for self-resolution or unknown resolution source)
- Adjust styling to ensure the dropdown spans the full width of its container

## Files Changed
- `src/components/ResolutionModal.tsx`
- `src/lib/constants.ts`
