### PR TITLE
(hotfix) Updated The Error Handing For Leaderboard Tab

### DIFF
--- a/frontend/components/Leaderboard/Leaderboard.tsx
+++ b/frontend/components/Leaderboard/Leaderboard.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { SlidersHorizontal } from 'lucide-react';
-import Link from 'next/link';
 import { useTheme } from 'next-themes';
 import { Loader2 } from "lucide-react";
 import fetchLeaderboard from "@/lib/api/fetchLeaderboard";
@@ -10,6 +9,7 @@ import { useUser } from "@/lib/contexts/UserContext";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
+import ErrorDisplay from '@/components/ui/error_display';
 
 type RankingType = 'country' | 'province' |'city' | 'suburb';
 
@@ -91,33 +91,25 @@ const Leaderboard: React.FC = () => {
 
   if (error) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[65vh] mt-10">
-        <h4 className="mb-4 text-4xl font-extrabold leading-none tracking-tight text-gray-900 md:text-5xl lg:text-6xl dark:text-white">Leaderboard data unavailable</h4>
-        <p className="mb-6 text-lg font-normal text-gray-500 lg:text-xl sm:px-16 xl:px-48 dark:text-gray-400">Please check your internet connection. Reload the page if the iissue persists or try login again.</p>
-        <Link href="/login" className="inline-flex items-center justify-center px-5 py-3 text-base font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 dark:focus:ring-blue-900">
-          Login Here
-          <svg className="w-3.5 h-3.5 ms-2 rtl:rotate-180" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 10">
-            <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M1 5h12m0 0L9 1m4 4L9 9"/>
-          </svg>
-        </Link>
-      </div>
+      <ErrorDisplay
+        title="Leaderboard data unavailable"
+        message="Please check your internet connection. Reload the page if the issue persists or try logging in again."
+        linkHref="/login"
+        linkText="Login Here"
+      />
     );
   }
-
+  
   if (!userData) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[65vh] mt-10">
-        <h4 className="mb-4 text-4xl font-extrabold leading-none tracking-tight text-gray-900 md:text-5xl lg:text-6xl dark:text-white">No user data available</h4>
-        <p className="mb-6 text-lg font-normal text-gray-500 lg:text-xl sm:px-16 xl:px-48 dark:text-gray-400">You need to be logged in to view leaderboard information. Create an account or login to an existing account.</p>
-        <Link href="/login" className="inline-flex items-center justify-center px-5 py-3 text-base font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 dark:focus:ring-blue-900">
-          Login Here
-          <svg className="w-3.5 h-3.5 ms-2 rtl:rotate-180" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 10">
-            <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M1 5h12m0 0L9 1m4 4L9 9"/>
-          </svg>
-        </Link>
-      </div>
+      <ErrorDisplay
+        title="No user data available"
+        message="You need to be logged in to view leaderboard information. Create an account or log in to an existing account."
+        linkHref="/login"
+        linkText="Login Here"
+      />
     );
-  }
+  }  
 
   return (
     <div className={`min-h-screen p-4 max-w-7xl max-h-8xl mx-auto w-full relative ${theme === 'dark' ? 'bg-[#0C0A09] text-[#f5f5f5]' : 'bg-white text-gray-800'}`}>

--- a/frontend/components/Leaderboard/Leaderboard.tsx
+++ b/frontend/components/Leaderboard/Leaderboard.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { SlidersHorizontal } from 'lucide-react';
+import Link from 'next/link';
 import { useTheme } from 'next-themes';
 import { Loader2 } from "lucide-react";
 import fetchLeaderboard from "@/lib/api/fetchLeaderboard";
@@ -89,11 +90,33 @@ const Leaderboard: React.FC = () => {
   }
 
   if (error) {
-    return <div>Error: {error}</div>;
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[65vh] mt-10">
+        <h4 className="mb-4 text-4xl font-extrabold leading-none tracking-tight text-gray-900 md:text-5xl lg:text-6xl dark:text-white">Leaderboard data unavailable</h4>
+        <p className="mb-6 text-lg font-normal text-gray-500 lg:text-xl sm:px-16 xl:px-48 dark:text-gray-400">Please check your internet connection. Reload the page if the iissue persists or try login again.</p>
+        <Link href="/login" className="inline-flex items-center justify-center px-5 py-3 text-base font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 dark:focus:ring-blue-900">
+          Login Here
+          <svg className="w-3.5 h-3.5 ms-2 rtl:rotate-180" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 10">
+            <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M1 5h12m0 0L9 1m4 4L9 9"/>
+          </svg>
+        </Link>
+      </div>
+    );
   }
 
   if (!userData) {
-    return <div>No user data available</div>;
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[65vh] mt-10">
+        <h4 className="mb-4 text-4xl font-extrabold leading-none tracking-tight text-gray-900 md:text-5xl lg:text-6xl dark:text-white">No user data available</h4>
+        <p className="mb-6 text-lg font-normal text-gray-500 lg:text-xl sm:px-16 xl:px-48 dark:text-gray-400">You need to be logged in to view leaderboard information. Create an account or login to an existing account.</p>
+        <Link href="/login" className="inline-flex items-center justify-center px-5 py-3 text-base font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 dark:focus:ring-blue-900">
+          Login Here
+          <svg className="w-3.5 h-3.5 ms-2 rtl:rotate-180" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 10">
+            <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M1 5h12m0 0L9 1m4 4L9 9"/>
+          </svg>
+        </Link>
+      </div>
+    );
   }
 
   return (

--- a/frontend/components/Notifications/NotificationsList.tsx
+++ b/frontend/components/Notifications/NotificationsList.tsx
@@ -9,6 +9,7 @@ import { formatRelativeTime } from "@/lib/formatRelativeTime";
 import { subscribe } from "@/lib/api/subscription";
 import { useQuery } from "@tanstack/react-query";
 import { useUser } from "@/lib/contexts/UserContext";
+import ErrorDisplay from '@/components/ui/error_display';
 
 import type { NotificationType } from "@/lib/types";
 
@@ -66,16 +67,12 @@ const NotificationsList: React.FC = () => {
 
   if (!data || isError) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[65vh] mt-10">
-        <h4 className="mb-4 text-4xl font-extrabold leading-none tracking-tight text-gray-900 md:text-5xl lg:text-6xl dark:text-white">No Notifications</h4>
-        <p className="mb-6 text-lg font-normal text-gray-500 lg:text-xl sm:px-16 xl:px-48 dark:text-gray-400">You currently have no notifications. Once you receive notifications, they will appear here.</p>
-        <Link href="/" className="inline-flex items-center justify-center px-5 py-3 text-base font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 dark:focus:ring-blue-900">
-          View Issues
-          <svg className="w-3.5 h-3.5 ms-2 rtl:rotate-180" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 10">
-            <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M1 5h12m0 0L9 1m4 4L9 9"/>
-          </svg>
-        </Link>
-      </div>
+      <ErrorDisplay
+        title="No Notifications"
+        message="You currently have no notifications. Once you receive notifications, they will appear here"
+        linkHref="/"
+        linkText="View Issues"
+      />
     );
   }
 

--- a/frontend/components/ui/error_display.tsx
+++ b/frontend/components/ui/error_display.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+import { ErrorDisplayProps } from "@/lib/types";
+
+const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ title, message, linkHref, linkText }) => {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[65vh] mt-10">
+      <h4 className="mb-4 text-4xl font-extrabold leading-none tracking-tight text-gray-900 md:text-5xl lg:text-6xl dark:text-white">
+        {title}
+      </h4>
+      <p className="mb-6 text-lg font-normal text-gray-500 lg:text-xl sm:px-16 xl:px-48 dark:text-gray-400">
+        {message}
+      </p>
+      <Link
+        href={linkHref}
+        className="inline-flex items-center justify-center px-5 py-3 text-base font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 dark:focus:ring-blue-900"
+      >
+        {linkText}
+        <svg
+          className="w-3.5 h-3.5 ms-2 rtl:rotate-180"
+          aria-hidden="true"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 14 10"
+        >
+          <path
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            d="M1 5h12m0 0L9 1m4 4L9 9"
+          />
+        </svg>
+      </Link>
+    </div>
+  );
+};
+
+export default ErrorDisplay;

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -382,6 +382,13 @@ interface CommentListProps2 {
   showComments?: boolean;
 }
 
+interface ErrorDisplayProps {
+  title: string;
+  message: string;
+  linkHref: string;
+  linkText: string;
+}
+
 export type {
   AnalysisResult,
   FeedProps,
@@ -420,5 +427,6 @@ export type {
   Resolution,
   ReactionNotification,
   CommentNotification,
-  NotificationType
+  NotificationType,
+  ErrorDisplayProps
 };


### PR DESCRIPTION
# Changes Made 
- Added a Component for displaying the appropriate content for the errors/feedback.
- Integrated the Component in the Leaderboard and Notifications Page

![Screenshot from 2024-08-09 16-55-43](https://github.com/user-attachments/assets/eb370860-06fb-4b7b-be88-91703681e22e)
![Screenshot from 2024-08-09 16-56-12](https://github.com/user-attachments/assets/18049873-bf9a-4ddf-ba13-6f530c4f0f7b)