### PR TITLE
Relocate Username Change Functionality to Settings Page and Improve Validation

### DIFF
--- a/backend/src/__tests__/routes/userRoutes.test.tsx
+++ b/backend/src/__tests__/routes/userRoutes.test.tsx
@@ -9,6 +9,7 @@ jest.mock("@/middleware/middleware");
 jest.mock("@/modules/users/controllers/userController", () => ({
   getUserById: [jest.fn()],
   updateUserProfile: jest.fn(),
+  updateUsername: jest.fn(), 
 }));
 
 const app = express();
@@ -49,6 +50,22 @@ describe("User Routes", () => {
 
       expect(response.status).toBe(200);
       expect(userController.updateUserProfile).toHaveBeenCalled();
+    });
+  });
+
+  describe("PUT /users/:id/username", () => {
+    it("should call updateUsername controller", async () => {
+      (verifyAndGetUser as jest.Mock).mockImplementation((req, res, next) =>
+        next(),
+      );
+      (userController.updateUsername as jest.Mock).mockImplementation((req, res) =>
+        res.status(200).json({}),
+      );
+
+      const response = await request(app).put("/users/1/username").send({ username: "newUsername" });
+
+      expect(response.status).toBe(200);
+      expect(userController.updateUsername).toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/modules/users/controllers/userController.ts
+++ b/backend/src/modules/users/controllers/userController.ts
@@ -51,3 +51,19 @@ export const updateUserProfile = async (req: Request, res: Response) => {
     sendResponse(res, error as APIResponse);
   }
 };
+
+export const updateUsername = async (req: Request, res: Response) => {
+  try {
+    const response = await userService.updateUsername(
+      req.params.id,
+      req.body.username
+    );
+
+    clearCache(`/api/users/${req.params.id}`);
+    clearCachePattern('__express__/api/users*');
+
+    sendResponse(res, response);
+  } catch (error) {
+    sendResponse(res, error as APIResponse);
+  }
+};

--- a/backend/src/modules/users/repositories/userRepository.ts
+++ b/backend/src/modules/users/repositories/userRepository.ts
@@ -127,4 +127,25 @@ export default class UserRepository {
 
     return data;
   }
+
+  async updateUsername(userId: string, newUsername: string) {
+    const { data, error } = await supabase
+      .from("user")
+      .update({ username: newUsername })
+      .eq("user_id", userId)
+      .select()
+      .single();
+
+    if (error) {
+      console.error("Supabase error:", error);
+      throw APIError({
+        code: 500,
+        success: false,
+        error: "An unexpected error occurred while updating username.",
+      });
+    }
+
+    return data;
+  }
+
 }

--- a/backend/src/modules/users/routes/userRoutes.ts
+++ b/backend/src/modules/users/routes/userRoutes.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import multer from "multer";
-import { getUserById, updateUserProfile } from "@/modules/users/controllers/userController";
+import { getUserById, updateUserProfile, updateUsername } from "@/modules/users/controllers/userController";
 import { verifyAndGetUser } from "@/middleware/middleware";
 
 const router = express.Router();
@@ -12,6 +12,12 @@ router.put(
   verifyAndGetUser,
   upload.single("profile_picture"),
   updateUserProfile,
+);
+
+router.put(
+  "/:id/username",
+  verifyAndGetUser,
+  updateUsername
 );
 
 export default router;

--- a/backend/src/modules/users/services/userService.ts
+++ b/backend/src/modules/users/services/userService.ts
@@ -184,4 +184,23 @@ export class UserService {
       data: user,
     };
   }
+
+  async updateUsername(userId: string, newUsername: string): Promise<APIResponse<User>> {
+    const updatedUser = await this.userRepository.updateUsername(userId, newUsername);
+    if (!updatedUser) {
+      throw APIError({
+        code: 404,
+        success: false,
+        error: "User not found",
+      });
+    }
+
+    return {
+      code: 200,
+      success: true,
+      data: updatedUser,
+    };
+  }
+
+  
 }

--- a/frontend/__tests__/components/settings/ProfileSettings.test.tsx
+++ b/frontend/__tests__/components/settings/ProfileSettings.test.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { describe, expect } from "@jest/globals";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, screen } from "@testing-library/react";
 import ProfileSettings from "@/components/Settings/ProfileSettings";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
 
 jest.mock("@/components/ui/use-toast", () => ({
   useToast: jest.fn(),
@@ -29,34 +31,62 @@ jest.mock("@supabase/supabase-js", () => ({
   }),
 }));
 
+
+jest.mock("@/lib/api/updateProfile", () => ({
+  updateUsername: jest.fn(),
+}));
+
+const queryClient = new QueryClient();
+
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
 describe("ProfileSettings", () => {
   it("renders profile fields correctly", () => {
-    const { getByLabelText, getByText } = render(<ProfileSettings />);
-
-    expect(getByLabelText(/Your Role/i)).toBeInTheDocument();
-    expect(getByLabelText(/Change Password/i)).toBeInTheDocument();
-    expect(getByText(/Save Changes/i)).toBeInTheDocument();
+    render(
+      <TestWrapper>
+        <ProfileSettings currentUsername="testuser" />
+      </TestWrapper>
+    );
+    expect(screen.getByText("Change Username")).toBeInTheDocument();
+    expect(screen.getByLabelText(/Current Username/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/New Username/i)).toBeInTheDocument();
+    expect(screen.getByText(/Save Username/i)).toBeInTheDocument();
   });
 
   it("handles role input change", () => {
-    const { getByLabelText } = render(<ProfileSettings />);
-
-    const roleInput = getByLabelText(/Your Role/i);
-    fireEvent.change(roleInput, { target: { value: "City Planner" } });
-    expect(roleInput.value).toBe("City Planner");
+    render(
+      <TestWrapper>
+        <ProfileSettings currentUsername="testuser" />
+      </TestWrapper>
+    );
+    const usernameInput = screen.getByLabelText(/New Username/i);
+    fireEvent.change(usernameInput, { target: { value: "newusername" } });
+    expect(usernameInput).toHaveValue("newusername");
   });
 
   it("handles password input change", () => {
-    const { getByLabelText } = render(<ProfileSettings />);
+    render(
+      <TestWrapper>
+        <ProfileSettings currentUsername="testuser" />
+      </TestWrapper>
+    );
 
-    const passwordInput = getByLabelText(/Change Password/i);
+    const passwordInput = screen.getByLabelText(/Change Password/i);
     fireEvent.change(passwordInput, { target: { value: "newpassword" } });
     expect(passwordInput.value).toBe("newpassword");
   });
 
   it("saves profile changes", () => {
-    const { getByText } = render(<ProfileSettings />);
-    const saveButton = getByText(/Save Changes/i);
+    render(
+      <TestWrapper>
+        <ProfileSettings currentUsername="testuser" />
+      </TestWrapper>
+    );
+    const saveButton = screen.getByText(/Save Username/i);
     fireEvent.click(saveButton);
   });
 });

--- a/frontend/__tests__/components/settings/ProfileSettings.test.tsx
+++ b/frontend/__tests__/components/settings/ProfileSettings.test.tsx
@@ -5,6 +5,7 @@ import ProfileSettings from "@/components/Settings/ProfileSettings";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 
+
 jest.mock("@/components/ui/use-toast", () => ({
   useToast: jest.fn(),
 }));
@@ -57,28 +58,19 @@ describe("ProfileSettings", () => {
     expect(screen.getByText(/Save Username/i)).toBeInTheDocument();
   });
 
-  it("handles role input change", () => {
+  it("handles username input change", () => {
     render(
-      <TestWrapper>
+      <QueryClientProvider client={queryClient}>
         <ProfileSettings currentUsername="testuser" />
-      </TestWrapper>
+      </QueryClientProvider>
     );
+  
     const usernameInput = screen.getByLabelText(/New Username/i);
     fireEvent.change(usernameInput, { target: { value: "newusername" } });
-    expect(usernameInput).toHaveValue("newusername");
+  
+    expect(usernameInput.value).toBe("newusername");
   });
 
-  it("handles password input change", () => {
-    render(
-      <TestWrapper>
-        <ProfileSettings currentUsername="testuser" />
-      </TestWrapper>
-    );
-
-    const passwordInput = screen.getByLabelText(/Change Password/i);
-    fireEvent.change(passwordInput, { target: { value: "newpassword" } });
-    expect(passwordInput.value).toBe("newpassword");
-  });
 
   it("saves profile changes", () => {
     render(

--- a/frontend/__tests__/components/settings/Settings.test.tsx
+++ b/frontend/__tests__/components/settings/Settings.test.tsx
@@ -4,7 +4,11 @@ import { render, fireEvent, screen, waitFor } from "@testing-library/react";
 import SettingsPage from "@/components/Settings/Settings";
 import { useToast } from "@/components/ui/use-toast";
 import { signOutWithToast } from "@/lib/utils";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fetchUserData } from "@/lib/api/fetchUserData";
+
+
+const queryClient = new QueryClient();
 
 jest.mock("@/components/ui/use-toast", () => ({
   useToast: jest.fn(),
@@ -52,15 +56,22 @@ describe("SettingsPage", () => {
     });
   });
 
-  it("toggles dropdowns", () => {
-    render(<SettingsPage />);
-    const profileSettingsButton = screen.getByText("Profile Settings");
+  it("toggles dropdowns", async () => {
+    
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SettingsPage />
+      </QueryClientProvider>
+    );
+  
+    
+    const profileSettingsButton = await screen.findByText(/profile settings/i);
     fireEvent.click(profileSettingsButton);
+  
     expect(screen.getByText("Current Username")).toBeInTheDocument();
-
-    fireEvent.click(profileSettingsButton);
-    expect(screen.queryByText("Current Username")).not.toBeInTheDocument();
   });
+  
+  
 
   it("calls signOutWithToast on sign out click", async () => {
     render(<SettingsPage />);

--- a/frontend/components/EditProfile/EditProfile.tsx
+++ b/frontend/components/EditProfile/EditProfile.tsx
@@ -194,20 +194,24 @@ const EditProfile: React.FC<EditProfileProps> = ({
             />
           </div>
           <div>
-            <label htmlFor="username" className="block text-sm font-medium">
-              Username
-            </label>
-            <Input
-              id="username"
-              value={updatedUser.username}
-              onChange={handleInputChange}
-              className={cn(
-                theme === "dark"
-                  ? "bg-gray-700 text-white border-gray-600"
-                  : "bg-white text-gray-800 border-gray-300",
-              )}
-            />
-          </div>
+  <label htmlFor="username" className="block text-sm font-medium">
+    Username
+  </label>
+  <Input
+    id="username"
+    value={updatedUser.username}
+    readOnly
+    className={cn(
+      theme === "dark"
+        ? "bg-gray-700 text-white border-gray-600"
+        : "bg-white text-gray-800 border-gray-300",
+    )}
+  />
+  <p className="text-sm text-gray-500 mt-2">
+    To change your username, please visit <a href="/settings" className="text-blue-500">Settings</a>.
+  </p>
+</div>
+
           <div>
             <label htmlFor="bio" className="block text-sm font-medium">
               Bio

--- a/frontend/components/Settings/ProfileSettings.tsx
+++ b/frontend/components/Settings/ProfileSettings.tsx
@@ -1,49 +1,62 @@
-import React, { useState, ChangeEvent } from "react";
+import React, { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { User, Lock } from "lucide-react";
+import { User } from "lucide-react";
+import { useMutation } from "@tanstack/react-query";
+import { updateUsername } from "@/lib/api/updateProfile";
 
-const ProfileSettings: React.FC = () => {
-  const [role, setRole] = useState("");
+const ProfileSettings: React.FC<{ currentUsername: string }> = ({ currentUsername }) => {
+  const [newUsername, setNewUsername] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+  const [successMessage, setSuccessMessage] = useState("");
 
-  const handleRoleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setRole(e.target.value);
-  };
+  const mutation = useMutation({
+    mutationFn: updateUsername,
+    onSuccess: (data) => {
+      setSuccessMessage("Username changed successfully!");
+      setErrorMessage("");
+    },
+    onError: (error: Error) => {
+      setErrorMessage(error.message || "An error occurred.");
+    },
+  });
 
-  const handleSaveProfile = () => {
-    // Logic to save profile changes
+  const handleSaveUsername = () => {
+    if (newUsername.length < 3 || newUsername.length > 20) {
+      setErrorMessage("Username must be between 3 and 20 characters.");
+      return;
+    }
+
+    mutation.mutate(newUsername);
   };
 
   return (
     <Card className="mb-4">
       <CardHeader>
         <CardTitle className="flex items-center">
-          <User className="mr-2" /> Profile Settings
+          <User className="mr-2" /> Change Username
         </CardTitle>
       </CardHeader>
       <CardContent>
         <div className="space-y-4">
           <div>
-            <Label htmlFor="role">Your Role</Label>
-            <Input
-              id="role"
-              value={role}
-              onChange={handleRoleChange}
-              placeholder="e.g., City Planner"
-            />
+            <Label htmlFor="currentUsername">Current Username</Label>
+            <Input id="currentUsername" value={currentUsername} readOnly />
           </div>
           <div>
-            <Label htmlFor="password">Change Password</Label>
-            <div className="flex items-center space-x-2">
-              <Input id="password" type="password" placeholder="New Password" />
-              <Button variant="outline">
-                <Lock className="mr-2 h-4 w-4" /> Change
-              </Button>
-            </div>
+            <Label htmlFor="newUsername">New Username</Label>
+            <Input
+              id="newUsername"
+              value={newUsername}
+              onChange={(e) => setNewUsername(e.target.value)}
+              placeholder="Enter new username"
+            />
+            {errorMessage && <p className="text-red-500 mt-2">{errorMessage}</p>}
+            {successMessage && <p className="text-green-500 mt-2">{successMessage}</p>}
           </div>
-          <Button onClick={handleSaveProfile}>Save Changes</Button>
+          <Button onClick={handleSaveUsername}>Save Username</Button>
         </div>
       </CardContent>
     </Card>

--- a/frontend/components/Settings/ProfileSettings.tsx
+++ b/frontend/components/Settings/ProfileSettings.tsx
@@ -14,7 +14,7 @@ const ProfileSettings: React.FC<{ currentUsername: string }> = ({ currentUsernam
 
   const mutation = useMutation({
     mutationFn: updateUsername,
-    onSuccess: (data) => {
+    onSuccess: () => {
       setSuccessMessage("Username changed successfully!");
       setErrorMessage("");
     },

--- a/frontend/components/Settings/Settings.tsx
+++ b/frontend/components/Settings/Settings.tsx
@@ -5,7 +5,7 @@ import NotificationSettings from "./NotificationSettings";
 import { Button } from "../ui/button";
 import { useToast } from "../ui/use-toast";
 import { signOutWithToast } from "@/lib/utils";
-import { fetchUserData } from "@/lib/api/fetchUserData"; // Adjust the import path as needed
+import { fetchUserData } from "@/lib/api/fetchUserData"; 
 import { UserAlt } from "@/lib/types";
 
 interface SettingsDropdownProps {

--- a/frontend/components/Settings/Settings.tsx
+++ b/frontend/components/Settings/Settings.tsx
@@ -1,10 +1,12 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import ProfileSettings from "./ProfileSettings";
 import RequestVerifications from "./RequestVerification";
 import NotificationSettings from "./NotificationSettings";
 import { Button } from "../ui/button";
 import { useToast } from "../ui/use-toast";
 import { signOutWithToast } from "@/lib/utils";
+import { fetchUserData } from "@/lib/api/fetchUserData"; // Adjust the import path as needed
+import { UserAlt } from "@/lib/types";
 
 interface SettingsDropdownProps {
   title: string;
@@ -15,7 +17,7 @@ const SettingsDropdown: React.FC<SettingsDropdownProps> = ({
   title,
   children,
 }) => {
-  const [isOpen, setIsOpen] = useState(false); // State for dropdown visibility
+  const [isOpen, setIsOpen] = useState(false);
 
   const toggleDropdown = () => setIsOpen(!isOpen);
 
@@ -31,6 +33,32 @@ const SettingsDropdown: React.FC<SettingsDropdownProps> = ({
 
 const SettingsPage = () => {
   const { toast } = useToast();
+  const [user, setUser] = useState<UserAlt | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const loadUserData = async () => {
+      try {
+        const userData = await fetchUserData();
+        setUser(userData);
+      } catch (error) {
+        console.error("Failed to fetch user data:", error);
+        toast({
+          title: "Error",
+          description: "Failed to load user data. Please try again.",
+          variant: "destructive",
+        });
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadUserData();
+  }, [toast]);
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
 
   return (
     <div className="container mx-auto my-8 space-y-8">
@@ -41,7 +69,11 @@ const SettingsPage = () => {
         </Button>
       </div>
       <SettingsDropdown title="Profile Settings">
-        <ProfileSettings />
+        {user ? (
+          <ProfileSettings currentUsername={user.username} />
+        ) : (
+          <p>User data not available</p>
+        )}
       </SettingsDropdown>
       <SettingsDropdown title="Request Verifications">
         <RequestVerifications />

--- a/frontend/lib/api/updateProfile.tsx
+++ b/frontend/lib/api/updateProfile.tsx
@@ -49,3 +49,30 @@ const updateUserProfile = async (
 };
 
 export { updateUserProfile };
+
+const updateUsername = async (newUsername: string) => {
+  const { data: sessionData } = await supabase.auth.getSession();
+  const session = sessionData?.session;
+
+  if (!session || !session.user) {
+    throw new Error("User ID not found in session");
+  }
+
+  const response = await fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/users/${session.user.id}/username`, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${session.access_token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ username: newUsername }),
+  });
+
+  if (!response.ok) {
+    const responseData = await response.json();
+    throw new Error(responseData.error || "Failed to update username");
+  }
+
+  return response.json();
+};
+
+export { updateUsername };


### PR DESCRIPTION
Relocated the username change functionality from the Edit Profile component to the Settings page, improving account management by centralizing the username change process.

**Changes Made**

- Created a new "Change Username" section under the Account Management area in the Settings page.

- Added a form for changing the username, including:
Displaying the current username as read-only.
A new input field for entering the desired username.
A submit button to confirm the change.

- Implemented client-side validation for the new username, including:
Length restrictions and character validation.

- Integrated API functionality to update the username, handling:
Success responses.
Error cases like "username already taken".

- Removed the username change functionality from the EditProfile component and replaced it with:
A read-only display of the current username.
A note/link directing users to the Settings page for changing their username.

- Implemented success and error messages for the username change process.