### PR TITLE
Fixed 'Failed to create organization' bug

### DIFF
--- a/frontend/lib/api/createOrganization.tsx
+++ b/frontend/lib/api/createOrganization.tsx
@@ -25,11 +25,11 @@ const createOrganization = async (
     body: JSON.stringify(organizationData),
   });
 
-  if (response.ok) {
-    const data = await response.json();
-    return data.organization as Organization;
+  const apiResponse = await response.json();
+
+  if (apiResponse.success) {
+    return apiResponse.data;
   } else {
-    const apiResponse = await response.json();
     throw new Error(apiResponse.error);
   }
 };


### PR DESCRIPTION
It was because of accessing the wrong property (`organization` instead of `data`) from the API response