### PR TITLE
Fixed organizations not deleting bug

### DIFF
--- a/backend/src/modules/organizations/controllers/organizationController.ts
+++ b/backend/src/modules/organizations/controllers/organizationController.ts
@@ -95,7 +95,7 @@ export const deleteOrganization = async (req: Request, res: Response) => {
       organizationId,
       userId,
     );
-    clearCachePattern(`__express__/api/organizations/${organizationId}`);
+    clearCachePattern(`__express__/api/organizations*`);
     sendResponse(res, response);
   } catch (err) {
     handleError(res, err);
@@ -322,7 +322,7 @@ export const getOrganizations = [
 
       const paginationParams: PaginationParams = {
         offset: Number(offset) || 0,
-        limit: Number(limit) || 10,
+        limit: Number(limit) || 99,
       };
 
       const response = await organizationService.getOrganizations(


### PR DESCRIPTION
I think it was because the org would stay in the cache after being deleted. The updated pattern should fix this.

Other:
I've increased the number of fetched organizations to 99, it was 10 before and wasn't showing the newly created organizations.